### PR TITLE
Flashメッセージを作成する

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -12,9 +12,9 @@ class Admin::BaseController < ApplicationController
 
   def admin_user
     # adminでない場合は、ログインページへリダイレクトさせる
-    unless current_user.admin?
-      flash[:danger] = '管理者のみ閲覧できます'
-      redirect_to admin_login_path
-    end
+    return if current_user.admin?
+
+    flash[:danger] = '管理者のみ閲覧できます'
+    redirect_to admin_login_path
   end
 end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -6,11 +6,15 @@ class Admin::BaseController < ApplicationController
 
   def not_authenticated
     # reuire_login時のredirect先を以下に変更する
+    flash[:danger] = 'ログインしてください'
     redirect_to admin_login_path
   end
 
   def admin_user
     # adminでない場合は、ログインページへリダイレクトさせる
-    redirect_to admin_login_path unless current_user.admin?
+    unless current_user.admin?
+      flash[:danger] = '管理者のみ閲覧できます'
+      redirect_to admin_login_path
+    end
   end
 end

--- a/app/controllers/admin/user_sessions_controller.rb
+++ b/app/controllers/admin/user_sessions_controller.rb
@@ -8,10 +8,10 @@ class Admin::UserSessionsController < Admin::BaseController
 
   def create
     @user = login(params[:email], params[:password])
-    if @user && @user.admin?
+    if @user&.admin?
       redirect_back_or_to(admin_users_path)
     else
-      flash.now[:notice] = 'ログインできませんでした'
+      flash.now[:danger] = 'ログインできませんでした'
       render :new
     end
   end

--- a/app/controllers/admin/user_sessions_controller.rb
+++ b/app/controllers/admin/user_sessions_controller.rb
@@ -1,6 +1,6 @@
 class Admin::UserSessionsController < Admin::BaseController
-  skip_before_action :admin_user, only: %i[new create]
   skip_before_action :require_login, only: %i[new create]
+  skip_before_action :admin_user, only: %i[new create]
 
   layout 'admin/layouts/admin_login'
 
@@ -11,12 +11,13 @@ class Admin::UserSessionsController < Admin::BaseController
     if @user && @user.admin?
       redirect_back_or_to(admin_users_path)
     else
+      flash.now[:notice] = 'ログインできませんでした'
       render :new
     end
   end
 
   def destroy
     logout
-    redirect_to admin_users_path
+    redirect_to admin_login_path
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -14,8 +14,10 @@ class Admin::UsersController < Admin::BaseController
   def create
     @user = User.new(user_params)
     if @user.save
+      flash[:success] = 'ユーザーを作成しました'
       redirect_to admin_users_path
     else
+      flash.now[:danger] = 'ユーザーの作成に失敗しました'
       render :new
     end
   end
@@ -24,8 +26,10 @@ class Admin::UsersController < Admin::BaseController
 
   def update
     if @user.update(user_params)
+      flash[:success] = 'ユーザーを更新しました'
       redirect_to admin_users_path
     else
+      flash.now[:danger] = 'ユーザーの更新に失敗しました'
       render :edit
     end
   end

--- a/app/javascript/stylesheets/application.css
+++ b/app/javascript/stylesheets/application.css
@@ -1,3 +1,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.danger{
+  @apply text-white z-10 mt-5 rounded-lg py-5 px-10 absolute right-10 shadow bg-red-300;
+}
+
+.success{
+  @apply text-white z-10 mt-5 rounded-lg py-5 px-10 absolute right-10 shadow bg-green-300;
+}

--- a/app/views/admin/layouts/admin_login.html.slim
+++ b/app/views/admin/layouts/admin_login.html.slim
@@ -10,5 +10,6 @@ html
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body.text-gray-600
+    = render 'shared/flash_message'
     = yield
     = render 'admin/shared/footer'

--- a/app/views/admin/layouts/application.html.slim
+++ b/app/views/admin/layouts/application.html.slim
@@ -11,5 +11,6 @@ html
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body.text-gray-600
     = render 'admin/shared/sidebar'
+    = render 'shared/flash_message'
     = yield
     = render 'admin/shared/footer'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,4 +10,5 @@ html
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body.bg-gray-100
+    = render 'shared/flash_message'
     = yield

--- a/app/views/shared/_flash_message.html.slim
+++ b/app/views/shared/_flash_message.html.slim
@@ -1,0 +1,3 @@
+- flash.each do |message_type, message|
+  div class="#{message_type}"
+    = message

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,7 @@ module.exports = {
         'main-green': '#8AEAE2',
         'light-green': '#43D6DB',
         'accent-red': '#FF6B92',
-        'light-red': '#FF86A6'
+        'light-red': '#FF86A6',
       },
     },
   },


### PR DESCRIPTION
## チケットへのリンク
#22 

## やったこと
flashメッセージを表示できるようにしました

## やらないこと
1. ログイン・ログアウトできた際はflashメッセージを表示していません（不要だと考えたため）。

## できるようになること（ユーザ目線）
1. ログインできなかった場合
2. ユーザー登録に成功・失敗した場合
3. ユーザー編集に成功・失敗した場合

以上の処理が行われた際にその旨のメッセージが右上に表示される

## できなくなること（ユーザ目線）

なし

## 動作確認
1. ログインできなかった場合
2. ユーザー登録に成功・失敗した場合
3. ユーザー編集に成功・失敗した場合

上記の場合でflashメッセージが表示されることを確認

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/63547176/162598763-36ca7623-5548-4ce7-9692-3818dd5861fe.png">
<img width="1440" alt="スクリーンショット 2022-04-10 11 37 35" src="https://user-images.githubusercontent.com/63547176/162598768-ca6eea34-c0c5-430a-b73c-e7c2b54dc520.png">


## その他

flashメッセージのクラスはapp/javascript/stylesheets/application.cssでクラス（success, danger）をまとめています。