### PR TITLE
add: 従業員用ログイン画面を作成 #11

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,0 +1,20 @@
+class UserSessionsController < ApplicationController
+  skip_before_action :require_login, only: %i[new create]
+
+  def new; end
+
+  def create
+    @user = login(params[:email], params[:password])
+    if @user
+      redirect_back_or_to(admin_users_path)
+    else
+      flash.now[:danger] = 'ログインできませんでした'
+      render :new
+    end
+  end
+
+  def destroy
+    logout
+    redirect_to login_path
+  end
+end

--- a/app/views/admin/user_sessions/new.html.slim
+++ b/app/views/admin/user_sessions/new.html.slim
@@ -5,4 +5,4 @@
       h1.text-white.font-bold.text-4xl ハタラクゾウ
       p.text-white.mt-1.mb-4.tracking-widest シンプルイズベストな勤怠管理アプリ
   .flex.justify-center.items-center.bg-white.w-1/2 
-    = render 'form'
+    = render 'shared/login_form', url: admin_login_path

--- a/app/views/shared/_login_form.html.slim
+++ b/app/views/shared/_login_form.html.slim
@@ -1,5 +1,5 @@
-= form_with url: admin_login_path, method: :post, local: true do |f|
-  .flex.flex-col.m-7
+= form_with url: url, method: :post, local: true do |f|
+  .flex.flex-col.m-7.border.p-5.rounded-lg.shadow.bg-white
     .mb-6
       = f.label :email, 'メールアドレス', class: 'block mb-1 text-sm font-medium text-gray-900 dark:text-gray-300'
       = f.text_field :email, size: 30, class: 'border-b-2 border-gray-400 text-gray-900 text-sm py-2.5 px-32'

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -1,0 +1,2 @@
+.flex.justify-center.items-center.min-h-screen
+  = render 'shared/login_form', url: login_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  get '/login', to: 'user_sessions#new'
+  post '/login', to: 'user_sessions#create'
+  delete '/logout', to: 'user_sessions#destroy'
   namespace :admin do
     get '/login', to: 'user_sessions#new'
     post '/login', to: 'user_sessions#create'

--- a/spec/requests/user_sessions_spec.rb
+++ b/spec/requests/user_sessions_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "UserSessions", type: :request do
+  describe "GET /new" do
+    it "returns http success" do
+      get "/user_sessions/new"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /create" do
+    it "returns http success" do
+      get "/user_sessions/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    it "returns http success" do
+      get "/user_sessions/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
## チケットへのリンク
#11 

## やったこと
従業員用ログイン画面を作成しました
→ /login

## やらないこと
ログアウトについては勤怠登録画面を作成したのち実装します

## できるようになること（ユーザ目線）
ログインできる

## できなくなること（ユーザ目線）
なし

## 動作確認
/loginへアクセスし、登録されたユーザーのアドレスでログインができる
