### PR TITLE
従業員画面で打刻機能を作成する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,9 @@ gem 'sorcery'
 # Pagination
 gem 'kaminari'
 
+# Decorator
+gem 'draper'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   #Debugger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (6.1.5)
       activesupport (= 6.1.5)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (6.1.5)
       activemodel (= 6.1.5)
       activesupport (= 6.1.5)
@@ -90,6 +94,13 @@ GEM
     crass (1.0.6)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
+    draper (4.0.2)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
+      ruby2_keywords
     enum_help (0.0.18)
       activesupport (>= 3.0.0)
     erubi (1.10.0)
@@ -214,6 +225,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.2.1)
+    request_store (1.5.1)
+      rack (>= 1.4)
     rexml (3.2.5)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
@@ -324,6 +337,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   capybara
+  draper
   enum_help
   factory_bot_rails
   faker

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -3,6 +3,7 @@ class AttendancesController < ApplicationController
   end
 
   def new
+    @current_user_last_attendance = current_user.attendances.last.decorate
   end
   
   def clockin

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,38 +1,33 @@
 class AttendancesController < ApplicationController
-  def index
-  end
+  def index; end
 
   def new
     @current_user_last_attendance = current_user.attendances.last.decorate
   end
-  
+
   def clockin
     @attendance = current_user.attendances.build(start_time: Time.zone.now)
-    if @attendance.save
-      flash[:success] = '出勤しました。がんばりましょう！'
-      redirect_to new_attendance_path
-    end
+    return unless @attendance.save
+
+    flash[:success] = '出勤しました。がんばりましょう！'
+    redirect_to new_attendance_path
   end
 
   def clockout
-    # 出勤時間があり、退勤時間がないもの
     @attendance = current_user.attendances.last
+    # 最新の勤怠状況から「出勤時間があり、退勤時間がないもの」に退勤時間を打刻する
     if @attendance && @attendance.end_time.nil?
       @attendance.update(end_time: Time.zone.now)
       flash[:success] = '退勤しました。お疲れ様でした！'
-      redirect_to new_attendance_path
     else
       flash[:danger] = '退勤に失敗しました。出勤を確認してください'
-      redirect_to new_attendance_path
     end
+    redirect_to new_attendance_path
   end
 
-  def edit
-  end
+  def edit; end
 
-  def update
-  end
+  def update; end
 
-  def destroy
-  end
+  def destroy; end
 end

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,0 +1,19 @@
+class AttendancesController < ApplicationController
+  def index
+  end
+
+  def new
+  end
+  
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+end

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -6,6 +6,10 @@ class AttendancesController < ApplicationController
   end
   
   def create
+    @attendances = current_user.attendances.build
+    # 出勤してなければstart_timeに時間を持たせる
+    if 
+    # 出勤していれば退勤時間を入れて保存する
   end
 
   def edit

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -5,11 +5,25 @@ class AttendancesController < ApplicationController
   def new
   end
   
-  def create
-    @attendances = current_user.attendances.build
-    # 出勤してなければstart_timeに時間を持たせる
-    if 
-    # 出勤していれば退勤時間を入れて保存する
+  def clockin
+    @attendance = current_user.attendances.build(start_time: Time.zone.now)
+    if @attendance.save
+      flash[:success] = '出勤しました。がんばりましょう！'
+      redirect_to new_attendance_path
+    end
+  end
+
+  def clockout
+    # 出勤時間があり、退勤時間がないもの
+    @attendance = current_user.attendances.last
+    if @attendance && @attendance.end_time.nil?
+      @attendance.update(end_time: Time.zone.now)
+      flash[:success] = '退勤しました。お疲れ様でした！'
+      redirect_to new_attendance_path
+    else
+      flash[:danger] = '退勤に失敗しました。出勤を確認してください'
+      redirect_to new_attendance_path
+    end
   end
 
   def edit

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,7 +6,7 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_back_or_to(admin_users_path)
+      redirect_back_or_to(new_attendance_path)
     else
       flash.now[:danger] = 'ログインできませんでした'
       render :new

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -1,0 +1,8 @@
+class ApplicationDecorator < Draper::Decorator
+  # Define methods for all decorated objects.
+  # Helpers are accessed through `helpers` (aka `h`). For example:
+  #
+  #   def percent_amount
+  #     h.number_to_percentage object.amount, precision: 2
+  #   end
+end

--- a/app/decorators/attendance_decorator.rb
+++ b/app/decorators/attendance_decorator.rb
@@ -1,0 +1,22 @@
+class AttendanceDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+  def is_clock_in?
+    # 勤怠情報で出勤しているかどうか判定するメソッド
+    if start_time.present? && end_time.nil?
+      return true
+    else
+      return false
+    end
+  end
+
+end

--- a/app/decorators/attendance_decorator.rb
+++ b/app/decorators/attendance_decorator.rb
@@ -10,13 +10,8 @@ class AttendanceDecorator < Draper::Decorator
   #     end
   #   end
 
-  def is_clock_in?
+  def clock_in?
     # 勤怠情報で出勤しているかどうか判定するメソッド
-    if start_time.present? && end_time.nil?
-      return true
-    else
-      return false
-    end
+    start_time.present? && end_time.nil?
   end
-
 end

--- a/app/javascript/current_time.js
+++ b/app/javascript/current_time.js
@@ -1,0 +1,10 @@
+getCurrentTime = () => {
+  var currentTime = new Date ();
+  var currentHour = currentTime.getHours();
+  var currentMin  = currentTime.getMinutes();
+  var currentSec  = currentTime.getSeconds();
+  var showCurrentTime = currentHour + ":" + currentMin + ":" + currentSec;
+  document.getElementById("currentTime").innerHTML = showCurrentTime;
+}
+
+setInterval('getCurrentTime()',1000);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,6 +9,8 @@ import * as ActiveStorage from "@rails/activestorage"
 import "channels"
 import "stylesheets/application.css"
 
+require ('current_time.js')
+
 Rails.start()
 Turbolinks.start()
 ActiveStorage.start()

--- a/app/javascript/stylesheets/application.css
+++ b/app/javascript/stylesheets/application.css
@@ -3,9 +3,9 @@
 @tailwind utilities;
 
 .danger{
-  @apply text-white z-10 mt-5 rounded-lg py-5 px-10 absolute right-10 shadow bg-red-300;
+  @apply text-white mt-16 rounded-lg py-5 px-10 absolute right-10 shadow bg-red-300;
 }
 
 .success{
-  @apply text-white z-10 mt-5 rounded-lg py-5 px-10 absolute right-10 shadow bg-green-300;
+  @apply text-white mt-16 rounded-lg py-5 px-10 absolute right-10 shadow bg-green-300;
 }

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -1,6 +1,6 @@
 .w-5/6.right-0.absolute
   .section.mx-8.pt-8
-    h1.font-semibold.text-3xl 従業員管理
+    h1.font-semibold.text-3xl.mb-10 従業員管理
     table.w-full.text-md.bg-slate-100.shadow-md.rounded.my-4
       tbody
         tr.border-b

--- a/app/views/attendances/new.html.slim
+++ b/app/views/attendances/new.html.slim
@@ -1,0 +1,2 @@
+.section.mx-8.pt-8
+  p.mt-20.text-center.text-5xl id="currentTime" 

--- a/app/views/attendances/new.html.slim
+++ b/app/views/attendances/new.html.slim
@@ -1,5 +1,5 @@
 .section.mx-8.pt-8
   p.mt-20.text-center.text-5xl id="currentTime"
   .flex.flex-col.text-center.items-center.my-20
-    = link_to '出勤する', '#', class: 'text-white bg-light-green hover:bg-main-green px-10 py-2 rounded-lg mb-10'
-    = link_to '退勤する', '#', class: 'text-white bg-accent-red hover:bg-light-red px-10 py-2 rounded-lg'
+    = link_to '出勤する', clockin_attendances_path, method: :post,  class: 'text-white bg-light-green hover:bg-main-green px-10 py-2 rounded-lg mb-10'
+    = link_to '退勤する', clockout_attendances_path, method: :post, class: 'text-white bg-accent-red hover:bg-light-red px-10 py-2 rounded-lg'

--- a/app/views/attendances/new.html.slim
+++ b/app/views/attendances/new.html.slim
@@ -1,5 +1,7 @@
 .section.mx-8.pt-8
   p.mt-20.text-center.text-5xl id="currentTime"
   .flex.flex-col.text-center.items-center.my-20
-    = link_to '出勤する', clockin_attendances_path, method: :post,  class: 'text-white bg-light-green hover:bg-main-green px-10 py-2 rounded-lg mb-10'
-    = link_to '退勤する', clockout_attendances_path, method: :post, class: 'text-white bg-accent-red hover:bg-light-red px-10 py-2 rounded-lg'
+    - if @current_user_last_attendance.is_clock_in?
+      = link_to '退勤する', clockout_attendances_path, method: :post, class: 'text-white bg-accent-red hover:bg-light-red px-10 py-2 rounded-lg'
+    - else
+      = link_to '出勤する', clockin_attendances_path, method: :post,  class: 'text-white bg-light-green hover:bg-main-green px-10 py-2 rounded-lg mb-10'

--- a/app/views/attendances/new.html.slim
+++ b/app/views/attendances/new.html.slim
@@ -1,2 +1,5 @@
 .section.mx-8.pt-8
-  p.mt-20.text-center.text-5xl id="currentTime" 
+  p.mt-20.text-center.text-5xl id="currentTime"
+  .flex.flex-col.text-center.items-center.my-20
+    = link_to '出勤する', '#', class: 'text-white bg-light-green hover:bg-main-green px-10 py-2 rounded-lg mb-10'
+    = link_to '退勤する', '#', class: 'text-white bg-accent-red hover:bg-light-red px-10 py-2 rounded-lg'

--- a/app/views/attendances/new.html.slim
+++ b/app/views/attendances/new.html.slim
@@ -1,7 +1,7 @@
 .section.mx-8.pt-8
   p.mt-20.text-center.text-5xl id="currentTime"
   .flex.flex-col.text-center.items-center.my-20
-    - if @current_user_last_attendance.is_clock_in?
+    - if @current_user_last_attendance.clock_in?
       = link_to '退勤する', clockout_attendances_path, method: :post, class: 'text-white bg-accent-red hover:bg-light-red px-10 py-2 rounded-lg'
     - else
       = link_to '出勤する', clockin_attendances_path, method: :post,  class: 'text-white bg-light-green hover:bg-main-green px-10 py-2 rounded-lg mb-10'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,5 +10,6 @@ html
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body.bg-gray-100
+    = render 'shared/header'
     = render 'shared/flash_message'
     = yield

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,7 +9,7 @@ html
     = stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload'
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
-  body.bg-gray-100
+  body.bg-gray-100.text-gray-600
     = render 'shared/header'
     = render 'shared/flash_message'
     = yield

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -1,6 +1,6 @@
 - if logged_in?
   header
-    nav.fixed.w-full.z-10.text-white.bg-light-green.py-3.px-4.md:px-16.md:flex.md:items-center.md:justify-between
+    nav.fixed.w-full.text-white.bg-light-green.py-3.px-4.md:px-16.md:flex.md:items-center.md:justify-between
       div.flex.justify-between
         = link_to root_path, class: "font-bold cursor-pointer flex" do
           = image_tag('logo.png', size: '25x25')

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -1,0 +1,20 @@
+- if logged_in?
+  header
+    nav.fixed.w-full.z-10.text-white.bg-light-green.py-3.px-4.md:px-16.md:flex.md:items-center.md:justify-between
+      div.flex.justify-between
+        = link_to root_path, class: "font-bold cursor-pointer flex" do
+          = image_tag('logo.png', size: '25x25')
+          p.ml-2.font-semibold.text-lg ハタラクゾウ
+      ul.md:flex.md:items-center.md:static.md:w-auto.md:py-0.md:pl-0.hidden
+        li.mx-4.my-6.md:my-0.flex
+          svg.h-6.w-6 fill="none" stroke="white" stroke-width="2" viewbox=("0 0 24 24") xmlns="http://www.w3.org/2000/svg" 
+            path d=("M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4") stroke-linecap="round" stroke-linejoin="round" 
+          = link_to '出勤する', new_attendance_path, class: 'text-white ml-2 text-base'
+        li.mx-4.my-6.md:my-0.flex
+          svg.h-6.w-6 fill="none" stroke="white" stroke-width="2" viewbox=("0 0 24 24") xmlns="http://www.w3.org/2000/svg" 
+            path d=("M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z") stroke-linecap="round" stroke-linejoin="round" 
+          = link_to '勤怠確認', attendances_path, class: 'text-white ml-2 text-base'
+        li.mx-4.my-6.md:my-0.flex
+          svg.h-6.w-6 fill="none" stroke="#FFFFFF" viewbox=("0 0 24 24") xmlns="http://www.w3.org/2000/svg" 
+            path d=("M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1") stroke-linecap="round" stroke-linejoin="round" 
+          = link_to 'ログアウト', logout_path, method: :delete, class: 'text-white font-semibold cursor-pointer ml-2 text-base'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
+  root 'user_sessions#new'
   get '/login', to: 'user_sessions#new'
   post '/login', to: 'user_sessions#create'
   delete '/logout', to: 'user_sessions#destroy'
+  resources :attendances
   namespace :admin do
     get '/login', to: 'user_sessions#new'
     post '/login', to: 'user_sessions#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,12 @@ Rails.application.routes.draw do
   get '/login', to: 'user_sessions#new'
   post '/login', to: 'user_sessions#create'
   delete '/logout', to: 'user_sessions#destroy'
-  resources :attendances
+  resources :attendances, only: %i[index new edit update destroy] do
+    collection do
+      post 'clockin'
+      post 'clockout'
+    end
+  end
   namespace :admin do
     get '/login', to: 'user_sessions#new'
     post '/login', to: 'user_sessions#create'

--- a/db/migrate/20220410131250_change_column_to_allow_null.rb
+++ b/db/migrate/20220410131250_change_column_to_allow_null.rb
@@ -1,0 +1,11 @@
+class ChangeColumnToAllowNull < ActiveRecord::Migration[6.1]
+  def up
+    change_column :attendances, :start_time, :datetime, null: true
+    change_column :attendances, :end_time, :datetime, null: true
+  end
+
+  def down
+    change_column :attendances, :start_time, :datetime, null: false
+    change_column :attendances, :end_time, :datetime, null: false
+  end
+end

--- a/db/migrate/20220410142833_add_user_id_to_attendances.rb
+++ b/db/migrate/20220410142833_add_user_id_to_attendances.rb
@@ -1,0 +1,5 @@
+class AddUserIdToAttendances < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :attendances, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_04_114449) do
+ActiveRecord::Schema.define(version: 2022_04_10_131250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "attendances", force: :cascade do |t|
-    t.datetime "start_time", null: false
-    t.datetime "end_time", null: false
+    t.datetime "start_time"
+    t.datetime "end_time"
     t.datetime "break_start"
     t.datetime "break_end"
     t.boolean "status", default: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_10_131250) do
+ActiveRecord::Schema.define(version: 2022_04_10_142833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 2022_04_10_131250) do
     t.boolean "status", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_attendances_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -36,4 +38,5 @@ ActiveRecord::Schema.define(version: 2022_04_10_131250) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "attendances", "users"
 end

--- a/spec/decorators/attendance_decorator_spec.rb
+++ b/spec/decorators/attendance_decorator_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe AttendanceDecorator do
+end

--- a/spec/requests/attendances_spec.rb
+++ b/spec/requests/attendances_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Attendances", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## チケットへのリンク
#8 

## やったこと
従業員画面で打刻機能を追加しました。
<img width="1414" alt="スクリーンショット 2022-04-12 15 29 31" src="https://user-images.githubusercontent.com/63547176/162895006-45a11cd0-cf57-48ed-88ce-16bcbaea1eb5.png">


## やらないこと
勤怠情報の編集・削除についてはまた別のチケットで対応します。
休憩時間の記録は期限に間に合えばおこないます。

## できるようになること（ユーザ目線）
打刻できるようになる

## できなくなること（ユーザ目線）

*なし

## 動作確認

* /attendance/newにて、出勤ボタンを押す。
* 同ページにリダイレクトされ、「出勤されました」というメッセージが表示される
* 退勤ボタンを押すと同ページにリダイレクトされ「退勤しました」というメッセージが表示される
* DBには、ログインユーザーの勤怠情報にボタンを押した時間が記録されている

以上のように確認しました。

## その他

*出勤時間と退勤時間を登録する際に、新規でclockin, clockoutアクションを作成しました。