### PR TITLE
管理画面で勤怠一覧機能をカレンダー形式で表示する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ gem 'kaminari'
 # Decorator
 gem 'draper'
 
+# Calendar
+gem "simple_calendar", "~> 2.4"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   #Debugger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
+    simple_calendar (2.4.3)
+      rails (>= 3.0)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -356,6 +358,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   sass-rails (>= 6)
+  simple_calendar (~> 2.4)
   slim-rails
   sorcery
   spring

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,6 +10,7 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
+ *= require simple_calendar
  *= require_tree .
  *= require_self
  */

--- a/app/controllers/admin/attendances_controller.rb
+++ b/app/controllers/admin/attendances_controller.rb
@@ -1,0 +1,8 @@
+class Admin::AttendancesController < Admin::BaseController
+  def index
+    @attendances = Attendance.includes(:user).all
+  end
+
+  def approve
+  end
+end

--- a/app/controllers/admin/attendances_controller.rb
+++ b/app/controllers/admin/attendances_controller.rb
@@ -3,6 +3,10 @@ class Admin::AttendancesController < Admin::BaseController
     @attendances = Attendance.includes(:user).all
   end
 
+  def show
+    @attendance = Attendance.find(params[:id])
+  end
+
   def approve
   end
 end

--- a/app/controllers/admin/attendances_controller.rb
+++ b/app/controllers/admin/attendances_controller.rb
@@ -7,6 +7,5 @@ class Admin::AttendancesController < Admin::BaseController
     @attendance = Attendance.find(params[:id])
   end
 
-  def approve
-  end
+  def approve; end
 end

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,5 +1,7 @@
 class AttendancesController < ApplicationController
-  def index; end
+  def index
+    @attendances = Attendance.includes(:user).all
+  end
 
   def new
     @current_user_last_attendance = current_user.attendances.last

--- a/app/decorators/admin/attendance_decorator.rb
+++ b/app/decorators/admin/attendance_decorator.rb
@@ -9,5 +9,4 @@ class Admin::AttendanceDecorator < ApplicationDecorator
   #       object.created_at.strftime("%a %m/%d/%y")
   #     end
   #   end
-
 end

--- a/app/decorators/admin/attendance_decorator.rb
+++ b/app/decorators/admin/attendance_decorator.rb
@@ -1,0 +1,13 @@
+class Admin::AttendanceDecorator < ApplicationDecorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/views/admin/attendances/approve.html.slim
+++ b/app/views/admin/attendances/approve.html.slim
@@ -1,0 +1,2 @@
+h1 Admin::Attendances#approve
+p Find me in app/views/admin/attendances/approve.html.slim

--- a/app/views/admin/attendances/index.html.slim
+++ b/app/views/admin/attendances/index.html.slim
@@ -5,4 +5,4 @@
       = date
       - attendances.each do |attendance|
         div
-          = attendance.user.name
+          = link_to "#{attendance.user.name} #{attendance.start_time.hour}時〜", admin_attendance_path(attendance)

--- a/app/views/admin/attendances/index.html.slim
+++ b/app/views/admin/attendances/index.html.slim
@@ -1,0 +1,8 @@
+.w-5/6.right-0.absolute
+  .section.mx-8.pt-8
+    h1.font-semibold.text-3xl.mb-10 勤怠管理
+    = month_calendar(events: @attendances) do |date, attendances|
+      = date
+      - attendances.each do |attendance|
+        div
+          = attendance.user.name

--- a/app/views/admin/attendances/show.html.slim
+++ b/app/views/admin/attendances/show.html.slim
@@ -1,0 +1,10 @@
+.w-5/6.right-0.absolute
+  .section.mx-8.pt-8
+    h1.font-semibold.text-3xl.mb-10 = "#{@attendance.user.name}さん　#{@attendance.created_at.month}月#{@attendance.created_at.day}日の勤怠詳細"
+    .mb-10
+      h3.font-semibold.text-2xl.my-10 出勤時間
+      = "#{@attendance.start_time.hour}時 #{@attendance.start_time.min}分"
+    .mb-10
+      h3.font-semibold.text-2xl.mb-10 退勤時間
+      = "#{@attendance.end_time.hour}時 #{@attendance.end_time.min}分"
+    h3.font-semibold.text-2xl.mb-10 承認ステータス

--- a/app/views/admin/shared/_sidebar.html.slim
+++ b/app/views/admin/shared/_sidebar.html.slim
@@ -1,7 +1,7 @@
 .w-60.h-full.shadow-md.px-1.absolute.bg-light-green
   ul.relative.top-12
     li.relative.mb-3
-      = link_to new_admin_user_path, class: 'flex items-center text-lg py-4 px-6 h-12 overflow-hidden text-white text-ellipsis whitespace-nowrap rounded hover:bg-main-green transition duration-300 ease-in-out' do
+      = link_to admin_attendances_path, class: 'flex items-center text-lg py-4 px-6 h-12 overflow-hidden text-white text-ellipsis whitespace-nowrap rounded hover:bg-main-green transition duration-300 ease-in-out' do
         svg.h-6.w-6.mr-3 fill="none" stroke="white" stroke-width="2" viewbox=("0 0 24 24") xmlns="http://www.w3.org/2000/svg" 
           path d=("M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4") stroke-linecap="round" stroke-linejoin="round" 
         span 勤怠管理

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   namespace :admin do
-    resources :attendances, only: %i[index] do
+    resources :attendances, only: %i[index show] do
       collection do
         get 'approve'
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,11 @@
 Rails.application.routes.draw do
+  namespace :admin do
+    resources :attendances, only: %i[index] do
+      collection do
+        get 'approve'
+      end
+    end
+  end
   root 'user_sessions#new'
   get '/login', to: 'user_sessions#new'
   post '/login', to: 'user_sessions#create'

--- a/spec/decorators/admin/attendance_decorator_spec.rb
+++ b/spec/decorators/admin/attendance_decorator_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe Admin::AttendanceDecorator do
+end

--- a/spec/requests/admin/attendances_spec.rb
+++ b/spec/requests/admin/attendances_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "Admin::Attendances", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/admin/attendances/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /approve" do
+    it "returns http success" do
+      get "/admin/attendances/approve"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
## チケットへのリンク
#7 
## やったこと
/admin/attendancesに勤怠情報を表示
/admin/attendance/:idに勤怠詳細を表示

## やらないこと

* 承認ステータスによる色の変化は別のチケットで行います

## できるようになること（ユーザ目線）

* 勤怠情報を確認できる

## できなくなること（ユーザ目線）

* なし

## 動作確認
<img width="1439" alt="スクリーンショット 2022-04-12 17 18 21" src="https://user-images.githubusercontent.com/63547176/162914490-4a18b5a1-5456-4324-ad48-5c0738d7d09e.png">
admin::attendance#indexにアクセスし、勤怠情報が表示されていることを確認
