### PR TITLE
add: 勤怠編集機能を追加 10#

### DIFF
--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,4 +1,5 @@
 class AttendancesController < ApplicationController
+  before_action :set_attendance, only: %i[edit update destroy show]
   def index
     @attendances = current_user.attendances
   end
@@ -29,7 +30,26 @@ class AttendancesController < ApplicationController
 
   def edit; end
 
-  def update; end
+  def update
+    if @attendance.update(attendance_params)
+      @attendance.update(status: :unapproved)
+      flash[:success] = '勤怠を更新しました！承認されるまでお待ちください'
+      redirect_to attendances_path
+    else
+      flash.now[:danger] = '更新に失敗しました'
+      render :edit
+    end
+  end
 
   def destroy; end
+
+  private
+
+  def set_attendance
+    @attendance = Attendance.find(params[:id])
+  end
+
+  def attendance_params
+    params.require(:attendance).permit(:start_time, :end_time).merge(user_id: current_user.id)
+  end
 end

--- a/app/views/attendances/edit.html.slim
+++ b/app/views/attendances/edit.html.slim
@@ -1,0 +1,12 @@
+.section.mx-8.pt-8
+  h1.font-semibold.text-3xl.my-10 勤怠編集
+  = form_with model: @attendance, url: attendance_path(@attendance), local: true do |f|
+    = render 'admin/shared/error_messages', object: f.object
+    .flex.flex-col.m-7
+      .mb-6
+        = f.label :start_time, class: 'block mb-1 text-sm font-medium text-gray-900 dark:text-gray-300'
+        = f.datetime_select :start_time, class: 'border-2 border-gray-200 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5'
+      .mb-6
+        = f.label :end_time, class: 'block mb-1 text-sm font-medium text-gray-900 dark:text-gray-300'
+        = f.datetime_select :end_time, class: 'border-2 border-gray-200 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5'
+      = f.button '更新する', class: 'text-white bg-accent-red rounded-full hover:bg-light-red font-semibold text-base px-5 py-2.5 text-center mr-2 shadow-md cursor-pointer w-1/4'


### PR DESCRIPTION
## チケットへのリンク
#10 
## やったこと
従業員画面で勤怠の編集ができるようにした
<img width="1408" alt="スクリーンショット 2022-04-14 11 04 39" src="https://user-images.githubusercontent.com/63547176/163299539-a168e479-c6ab-47ee-8743-75cd99233c14.png">

## できるようになること（ユーザ目線）
勤怠の編集ができる

## できなくなること（ユーザ目線）
なし

## 動作確認
attendance#editで勤怠を更新する
attendance#indexで反映されていることを確認

## その他
承認済みのものでも更新すると承認ステータスを未承認に変更している