### PR TITLE
削除機能を実装

### DIFF
--- a/app/controllers/admin/attendances_controller.rb
+++ b/app/controllers/admin/attendances_controller.rb
@@ -1,20 +1,31 @@
 class Admin::AttendancesController < Admin::BaseController
+  before_action :set_attendance, only: %i[approve destroy show]
+
   def index
     @attendances = Attendance.includes(:user).all
   end
 
-  def show
-    @attendance = Attendance.find(params[:id])
-  end
+  def show; end
 
   def unapproved
     @unapproved_attendances = Attendance.where(status: :unapproved)
   end
 
   def approve
-    @attendance = Attendance.find(params[:id])
     @attendance.update(status: :approved)
     flash[:success] = '承認しました！'
     redirect_to unapproved_admin_attendances_path
+  end
+
+  def destroy
+    @attendance.destroy!
+    flash[:success] = '勤怠を削除しました！'
+    redirect_to admin_attendances_path
+  end
+
+  private
+
+  def set_attendance
+    @attendance = Attendance.find(params[:id])
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -36,6 +36,8 @@ class Admin::UsersController < Admin::BaseController
 
   def destroy
     @user.destroy!
+    flash[:success] = 'ユーザーを削除しました！'
+    redirect_to admin_users_path
   end
 
   private

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -41,7 +41,13 @@ class AttendancesController < ApplicationController
     end
   end
 
-  def destroy; end
+  def destroy
+    if @attendance.user_id == current_user.id
+      @attendance.destroy!
+      flash[:success] = '勤怠を削除しました！'
+      redirect_to attendances_path
+    end
+  end
 
   private
 

--- a/app/views/admin/attendances/_unapproved_attendance.html.slim
+++ b/app/views/admin/attendances/_unapproved_attendance.html.slim
@@ -4,4 +4,4 @@ tr.border-b.hover:bg-orange-100.bg-slate-100
   td.p-3.px-5 = unapproved_attendance.end_time
   td.p-3.px-5
     = link_to '承認', approve_admin_attendance_path(unapproved_attendance), method: :post, class: 'mr-3 text-white bg-blue-400 hover:bg-blue-300 px-4 py-2 rounded-lg'
-    = link_to '削除', '#', class: 'mr-3 text-white bg-red-400 hover:bg-red-300 px-4 py-2 rounded-lg'
+    = link_to '削除', admin_attendance_path(unapproved_attendance), method: :delete, class: 'mr-3 text-white bg-red-400 hover:bg-red-300 px-4 py-2 rounded-lg'

--- a/app/views/admin/users/_user.html.slim
+++ b/app/views/admin/users/_user.html.slim
@@ -6,4 +6,4 @@ tr.border-b.hover:bg-orange-100.bg-slate-100
   td.p-3.px-5
     = link_to '詳細', admin_user_path(user), class: 'mr-3 text-white bg-blue-400 hover:bg-blue-300 px-4 py-2 rounded-lg'
     = link_to '編集', edit_admin_user_path(user), class: 'mr-3 text-white bg-green-400 hover:bg-green-300 px-4 py-2 rounded-lg'
-    = link_to '削除', '#', class: 'mr-3 text-white bg-red-400 hover:bg-red-300 px-4 py-2 rounded-lg'
+    = link_to '削除', admin_user_path(user), method: :delete, class: 'mr-3 text-white bg-red-400 hover:bg-red-300 px-4 py-2 rounded-lg'

--- a/app/views/attendances/edit.html.slim
+++ b/app/views/attendances/edit.html.slim
@@ -9,4 +9,6 @@
       .mb-6
         = f.label :end_time, class: 'block mb-1 text-sm font-medium text-gray-900 dark:text-gray-300'
         = f.datetime_select :end_time, class: 'border-2 border-gray-200 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5'
-      = f.button '更新する', class: 'text-white bg-accent-red rounded-full hover:bg-light-red font-semibold text-base px-5 py-2.5 text-center mr-2 shadow-md cursor-pointer w-1/4'
+      .mb-6
+        = f.button '更新する', class: 'text-white bg-accent-red rounded-full hover:bg-light-red font-semibold text-base px-5 py-2.5 text-center mr-2 shadow-md cursor-pointer w-1/4'
+      = link_to '削除する', attendance_path(@attendance), method: :delete, class: 'text-white bg-accent-red rounded-full hover:bg-light-red font-semibold text-base px-5 py-2.5 text-center mr-2 shadow-md cursor-pointer w-1/4'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   namespace :admin do
-    resources :attendances, only: %i[index show] do
+    resources :attendances, only: %i[index show destroy] do
       collection do
         get 'unapproved'
       end


### PR DESCRIPTION
## チケットへのリンク
#20 

## やったこと
ユーザー・勤怠の削除機能を実装

## やらないこと
なし

## できるようになること（ユーザ目線）
従業員：自分の勤怠を削除できる
管理者：ユーザーを削除できる・勤怠リクエストを削除できる
