### PR TITLE
Admin user#show

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -5,7 +5,9 @@ class Admin::UsersController < Admin::BaseController
     @users = User.page(params[:page])
   end
 
-  def show; end
+  def show
+    @attendances = @user.attendances
+  end
 
   def new
     @user = User.new

--- a/app/views/admin/layouts/admin_login.html.slim
+++ b/app/views/admin/layouts/admin_login.html.slim
@@ -12,4 +12,3 @@ html
   body.text-gray-600
     = render 'shared/flash_message'
     = yield
-    = render 'admin/shared/footer'

--- a/app/views/admin/layouts/application.html.slim
+++ b/app/views/admin/layouts/application.html.slim
@@ -13,4 +13,3 @@ html
     = render 'admin/shared/sidebar'
     = render 'shared/flash_message'
     = yield
-    = render 'admin/shared/footer'

--- a/app/views/admin/shared/_sidebar.html.slim
+++ b/app/views/admin/shared/_sidebar.html.slim
@@ -15,8 +15,13 @@
         svg.h-6.w-6.mr-3 fill="none" stroke="white" stroke-width="2" viewbox=("0 0 24 24") xmlns="http://www.w3.org/2000/svg" 
           path d=("M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z") stroke-linecap="round" stroke-linejoin="round" 
         span 従業員登録
-    li.relative
+    li.relative.mb-3
       = link_to admin_logout_path, method: :delete, class: 'flex items-center text-lg py-4 px-6 h-12 overflow-hidden text-white text-ellipsis whitespace-nowrap rounded hover:bg-main-green transition duration-300 ease-in-out' do
         svg.h-6.w-6.mr-3 fill="none" stroke="white" stroke-width="2" viewbox=("0 0 24 24") xmlns="http://www.w3.org/2000/svg" 
           path d=("M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1") stroke-linecap="round" stroke-linejoin="round" 
         span ログアウト
+    li.relative
+      = link_to admin_user_path(current_user), class: 'flex items-center text-lg py-4 px-6 h-12 overflow-hidden text-white text-ellipsis whitespace-nowrap rounded hover:bg-main-green transition duration-300 ease-in-out' do
+        svg.h-6.w-6.mr-3 fill="none" stroke="white" stroke-width="2" viewbox=("0 0 24 24") xmlns="http://www.w3.org/2000/svg" 
+          path d=("M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z") stroke-linecap="round" stroke-linejoin="round" 
+        span #{current_user.name}

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -1,2 +1,15 @@
-h1 Admin::User#show
-p Find me in app/views/admin/user/show.html.slim
+.w-5/6.right-0.absolute
+  .section.mx-8.pt-8
+    h1.font-semibold.text-3xl.mb-10 従業員勤怠情報
+    .mb-10 
+      p
+        span.px-2.bg-light-green.text-white.rounded-lg 青色
+        | ・・・承認済み
+      p
+        span.px-2.bg-accent-red.text-white.rounded-lg 赤色
+        | ・・・未承認
+    = month_calendar(events: @attendances) do |date, attendances|
+      = date
+      - attendances.each do |attendance|
+        div
+          = link_to "#{attendance.user.name} #{attendance.start_time.hour}時〜", admin_attendance_path(attendance), class: "#{attendance.status_color} text-white rounded-lg px-2"

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -6,15 +6,19 @@
           = image_tag('logo.png', size: '25x25')
           p.ml-2.font-semibold.text-lg ハタラクゾウ
       ul.md:flex.md:items-center.md:static.md:w-auto.md:py-0.md:pl-0.hidden
-        li.mx-4.my-6.md:my-0.flex
+        li.mx-4.my-6.my-0.flex
           svg.h-6.w-6 fill="none" stroke="white" stroke-width="2" viewbox=("0 0 24 24") xmlns="http://www.w3.org/2000/svg" 
             path d=("M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4") stroke-linecap="round" stroke-linejoin="round" 
           = link_to '出勤する', new_attendance_path, class: 'text-white ml-2 text-base'
-        li.mx-4.my-6.md:my-0.flex
+        li.mx-4.my-6.my-0.flex
           svg.h-6.w-6 fill="none" stroke="white" stroke-width="2" viewbox=("0 0 24 24") xmlns="http://www.w3.org/2000/svg" 
             path d=("M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z") stroke-linecap="round" stroke-linejoin="round" 
           = link_to '勤怠確認', attendances_path, class: 'text-white ml-2 text-base'
-        li.mx-4.my-6.md:my-0.flex
+        li.mx-4.my-6.my-0.flex
+          svg.h-6.w-6 fill="none" stroke="white" stroke-width="2" viewbox=("0 0 24 24") xmlns="http://www.w3.org/2000/svg" 
+            path d=("M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z") stroke-linecap="round" stroke-linejoin="round" 
+          p.text-white.font-semibold.ml-2.text-base #{current_user.name}
+        li.mx-4.my-6.my-0.flex
           svg.h-6.w-6 fill="none" stroke="#FFFFFF" viewbox=("0 0 24 24") xmlns="http://www.w3.org/2000/svg" 
             path d=("M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1") stroke-linecap="round" stroke-linejoin="round" 
           = link_to 'ログアウト', logout_path, method: :delete, class: 'text-white font-semibold cursor-pointer ml-2 text-base'


### PR DESCRIPTION
## チケットへのリンク
#34 

## やったこと
管理画面でユーザーの詳細画面を作成
header, sidebarでユーザーの名前を表示

## できるようになること（ユーザ目線）
管理画面でそのユーザーの勤務した日がわかる
現在ログインしている人が誰が明確になる

## できなくなること（ユーザ目線）

なし

## 動作確認
ユーザー詳細
<img width="1433" alt="スクリーンショット 2022-04-14 15 45 57" src="https://user-images.githubusercontent.com/63547176/163329171-f490ee1c-e4f1-4256-bdf1-79b2451716f1.png">



sidebar
<img width="245" alt="スクリーンショット 2022-04-14 15 45 28" src="https://user-images.githubusercontent.com/63547176/163329095-1f460a18-0d4f-48bd-83e1-3e42d30dfd21.png">

header
<img width="1430" alt="スクリーンショット 2022-04-14 15 44 58" src="https://user-images.githubusercontent.com/63547176/163329028-54d70494-e2b4-4d25-aafa-34388061d83e.png">
